### PR TITLE
Added new identificationKeyDone event 

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,14 @@
     "@typescript-eslint/eslint-plugin": "^5.36.0",
     "@typescript-eslint/parser": "^5.36.0",
     "eslint": "^8.23.0",
+    "happy-dom": "^8.3.2",
     "rollup": "^3.9.1",
     "rollup-plugin-terser": "^7.0.2",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.2",
-    "vitest": "^0.27.0",
-    "happy-dom": "^8.3.2"
+    "vitest": "^0.27.0"
+  },
+  "dependencies": {
+    "lodash": "^4.17.21"
   }
 }

--- a/src/features/NatureGuide.ts
+++ b/src/features/NatureGuide.ts
@@ -179,7 +179,7 @@ export enum IdentificationEvents {
   filterBecameInvisible = 'filterBecameInvisible',
 
   /**
-   * triggered when all possible choices are made or only one option is left
+   * triggered when all possible choices are made
    */
   identificationKeyDone = 'identificationKeyDone',
 }
@@ -531,7 +531,8 @@ export class IdentificationKey {
     this.results = this.sortNodes(this.children.filter((_, index) => this.possibleNodes[index] === 1));
     this.impossibleResults = this.sortNodes(this.children.filter((_, index) => this.possibleNodes[index] === 0));
 
-    if (this.results.length === 1 || this.doneFilters.every(v => v)) {
+    //if (this.results.length === 1 || this.doneFilters.every(v => v)) {
+    if (this.doneFilters.every(v => v)) {
       this.notifyListeners(
         IdentificationEvents.identificationKeyDone,
         { resultCount: this.results.length },

--- a/src/features/NatureGuide.ts
+++ b/src/features/NatureGuide.ts
@@ -1,8 +1,8 @@
-import { FeatureBase } from "../Features";
-import { Taxon } from "./BackboneTaxonomy";
-import { ImageUrls } from "../Image";
+import {FeatureBase} from "../Features";
+import {Taxon} from "./BackboneTaxonomy";
+import {ImageUrls} from "../Image";
 // this should be replaced with something independant
-import { cloneDeep } from "lodash";
+import {cloneDeep} from "lodash";
 
 export type MatrixFilterSpaceReference = {
   spaceIdentifier: string,
@@ -177,6 +177,11 @@ export enum IdentificationEvents {
   spaceDeselected = 'spaceDeselected',
   filterBecameVisible = 'filterBecameVisible',
   filterBecameInvisible = 'filterBecameInvisible',
+
+  /**
+   * triggered when all possible choices are made or only one option is left
+   */
+  identificationKeyDone = 'identificationKeyDone',
 }
 
 export type IdentificationEventCallback = {
@@ -525,12 +530,43 @@ export class IdentificationKey {
   computeResults() {
     this.results = this.sortNodes(this.children.filter((_, index) => this.possibleNodes[index] === 1));
     this.impossibleResults = this.sortNodes(this.children.filter((_, index) => this.possibleNodes[index] === 0));
+
+    if (this.results.length === 1 || this.doneFilters.every(v => v)) {
+      this.notifyListeners(
+        IdentificationEvents.identificationKeyDone,
+        { resultCount: this.results.length },
+      )
+    }
   }
 
   private sortNodes(nodes: IdentificationKeyReference[]) {
     return nodes.sort((a, b) => {
       return ((this.points[b.uuid] || 0) / b.maxPoints) - ((this.points[a.uuid] || 0) / a.maxPoints);
     });
+  }
+
+  /**
+   * Returns true for each visible filter that either has a selected space or no possible space
+   *
+   * Use with care, as this is an expensive operation.
+   */
+  get doneFilters () {
+    return Object.values(this.matrixFilters).map((filter, index) => {
+      if (this.visibleFilters[index] === 0) {
+        return true;
+      }
+
+      // for each visible filter, check if it has at least one selected or possible space
+      // if not, then it is impossible
+      const spaceIndices = filter.space.map((space) => this.findSpaceIndex(space))
+
+      const hasOneSelectedSpace = spaceIndices
+        .some((spaceIndex) => this.selectedSpaces[spaceIndex] === 1);
+      const hasNoPossibleSpace = spaceIndices
+        .every((spaceIndex) => this.possibleSpaces[spaceIndex] === 0);
+
+      return hasOneSelectedSpace || hasNoPossibleSpace;
+    }).map(possible => possible ? 1 : 0);
   }
 
   /***

--- a/tests/NatureGuide.spec.ts
+++ b/tests/NatureGuide.spec.ts
@@ -225,4 +225,93 @@ describe('IdentificationKey', () => {
       expect(key.points[key.children[2].uuid]).toEqual(2);
     })
   });
+
+  describe('identificationKeyDone event', () => {
+    test('is fired when only one result is left', () => {
+      const listener = vi.fn();
+      key.on(IdentificationEvents.identificationKeyDone, listener);
+      expect(listener).not.toHaveBeenCalled();
+
+      key.selectSpace(2);
+      expect(listener).toHaveBeenCalled();
+      expect(listener.mock.calls[0][0]).toEqual(IdentificationEvents.identificationKeyDone);
+      expect(listener.mock.calls[0][2].resultCount).toEqual(1);
+    });
+
+    test('is fired when all filters are selected', () => {
+      const natureGuide = new NatureGuide({
+        uid: "asd",
+        tree: {
+          a: {
+            uuid: "a",
+            name: "a",
+            children: [
+              {
+                uuid: 'b',
+                name: 'b',
+                space: {
+                  f1: [{ spaceIdentifier: 'f1:0', encodedSpace: [0] }],
+                  f2: [{ spaceIdentifier: 'f2:0', encodedSpace: [0] }],
+                }
+              },
+              {
+                uuid: 'c',
+                name: 'c',
+                space: {
+                  f1: [{ spaceIdentifier: 'f1:0', encodedSpace: [0] }],
+                  f2: [{ spaceIdentifier: 'f2:0', encodedSpace: [0] }],
+                }
+              },
+            ],
+            matrixFilters: {
+              f1: {
+                uuid: 'f1',
+                name: 'f1',
+                type: "ColorFilter",
+                space: [
+                  { spaceIdentifier: 'f1:0', encodedSpace: [0] },
+                  { spaceIdentifier: 'f1:1', encodedSpace: [0] },
+                ]
+              },
+              f2: {
+                uuid: 'f2',
+                name: 'f2',
+                type: "ColorFilter",
+                space: [
+                  { spaceIdentifier: 'f2:0', encodedSpace: [0] },
+                  { spaceIdentifier: 'f2:1', encodedSpace: [0] },
+                ]
+              },
+            }
+          }
+        }
+      } as any as NatureGuide);
+      key = natureGuide.getIdentificationKey('a') as IdentificationKey;
+
+      const listener = vi.fn();
+      key.on(IdentificationEvents.identificationKeyDone, listener);
+      expect(listener).not.toHaveBeenCalled();
+
+      key.selectSpace(0);
+      key.selectSpace(2);
+
+      expect(listener).toHaveBeenCalled();
+      expect(listener.mock.calls[0][0]).toEqual(IdentificationEvents.identificationKeyDone);
+      expect(listener.mock.calls[0][2].resultCount).toEqual(2);
+    })
+  })
+
+  describe('doneFilters', () => {
+    test('selecting a space marks the filter as done', () => {
+      expect(key.doneFilters).toEqual([0, 0, 0, 0, 0, 0, 1]);
+      key.selectSpace(1);
+      expect(key.doneFilters).toEqual([1, 0, 0, 1, 0, 0, 1]);
+    })
+
+    test('selecting a space for a filter where multiple spaces are allowed marks the filter as done', () => {
+      expect(key.doneFilters).toEqual([0, 0, 0, 0, 0, 0, 1]);
+      key.selectSpace(0);
+      expect(key.doneFilters).toEqual([1, 0, 0, 0, 0, 0, 0]);
+    })
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1291,6 +1291,11 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 loupe@^2.3.1:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.6.tgz#76e4af498103c532d1ecc9be102036a21f787b53"


### PR DESCRIPTION
This event fires when:

- only one result remains
- for all filters either:
  - it is invisible
  - ...or a space is selected
  - ...or no space is possible

this allows to listen for `identificationKeyDone` and display information to the user or route them to the results page automatically